### PR TITLE
CMakeLists: Remove webos_machine_impl_dep call

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,6 @@ include_directories(${PMLOGLIB_INCLUDE_DIRS})
 link_directories(${PMLOGLIB_LIBRARY_DIRS})
 webos_add_compiler_flags(ALL ${PMLOGLIB_CFLAGS_OTHER})
 
-webos_machine_impl_dep()
 include(webOS/LegacyDefines)
 
 webos_include_install_paths()


### PR DESCRIPTION
* we're not interested in different behavior for emulator or desktop build
  calling this causes WEBOS_TARGET_MACHINE_IMPL to be set to simulator
  and webOS/LegacyDefines.cmake to define TARGET_DESKTOP

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>
Signed-off-by: Simon Busch <morphis@gravedo.de>