### PR TITLE
luna-service2: Add permissions for com.palm and org.webosports

### DIFF
--- a/files/sysbus/com.webos.lunasend.role.json.in
+++ b/files/sysbus/com.webos.lunasend.role.json.in
@@ -6,6 +6,10 @@
         {
             "service": "com.webos.lunasend-*",
             "outbound": ["*"]
+        },
+        {
+            "service": "org.webosports.lunasend-*",
+            "outbound": ["*"]
         }
     ]
 }

--- a/files/sysbus/com.webos.lunasendpub.role.json.in
+++ b/files/sysbus/com.webos.lunasendpub.role.json.in
@@ -6,6 +6,10 @@
         {
             "service": "com.webos.lunasendpub-*",
             "outbound": ["*"]
+        },
+        {
+            "service": "org.webosports.lunasendpub-*",
+            "outbound": ["*"]
         }
     ]
 }

--- a/files/sysbus/ls-monitor.role.json.in
+++ b/files/sysbus/ls-monitor.role.json.in
@@ -6,6 +6,14 @@
         {
             "service":"com.webos.monitor*",
             "outbound":["*"]
+        },
+        {
+            "service":"com.palm.monitor*",
+            "outbound":["*"]
+        },
+        {
+            "service":"org.webosports.monitor*",
+            "outbound":["*"]
         }
     ]
 }

--- a/files/sysbus/luna-service2.perm.json
+++ b/files/sysbus/luna-service2.perm.json
@@ -1,5 +1,9 @@
 {
   "*": ["luna.internal.public"],
   "com.webos.monitor*": ["luna.internal"],
-  "com.webos.lunasend-*": ["all"]
+  "com.palm.monitor*": ["luna.internal"],
+  "org.webosports.monitor*": ["luna.internal"],
+  "com.webos.lunasend-*": ["all"],
+  "com.palm.lunasend-*": ["all"],
+  "org.webosports.lunasend-*": ["all"]
 }


### PR DESCRIPTION
To solve various issues when trying to register a service from another service such as:

Jun 18 18:15:11 hammerhead webos-telephonyd[1158]: Failed to initialize the Luna Palm service: Invalid permissions for com.palm.telephony
Jun 18 18:15:11 hammerhead webos-telephonyd[1158]: Failed to initialize the WAN service: Invalid permissions for com.palm.wan
Jun 18 18:15:11 hammerhead webos-telephonyd[1158]: Cleaning up

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>